### PR TITLE
Fix documentation: Add a step for Nuxts setups in 2.installation.md

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -27,8 +27,30 @@ bun add -D vue-email
 
 ::
 
+2. (Optional) If you plan to use in a Nuxt application also add the `@vue-email/nuxt` dependency:
 
-1. Load in your vue project:
+::code-group
+
+```sh [pnpm]
+pnpm i @vue-email/nuxt
+```
+
+```bash [yarn]
+yarn add @vue-email/nuxt
+```
+
+```bash [npm]
+npm install @vue-email/nuxt
+```
+
+```bash [bun]
+bun add @vue-email/nuxt
+```
+
+::
+
+
+3. Load in your vue project:
 
 ::code-group
 


### PR DESCRIPTION
In order to use `@vue-email/nuxt` it has to be added to the project dependencies as well.

By the way, why is the `vue-email` dependency added as a _development_ dependency and not a regular dependency, please?

Thanks in advance.