### PR TITLE
Fix the vue peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prepare": "simple-git-hooks"
   },
   "peerDependencies": {
-    "vue": "3.3.4"
+    "vue": "^3.3.4"
   },
   "dependencies": {
     "@flowko/tw-to-css": "^0.0.6",


### PR DESCRIPTION
Fix the peer dependency for Vue to not require a specific version. Fixes #122